### PR TITLE
Remove abstractmethod decorators from define methods

### DIFF
--- a/src/brim/bicycle/front_frames.py
+++ b/src/brim/bicycle/front_frames.py
@@ -61,10 +61,6 @@ class RigidFrontFrame(FrontFrameBase):
         super().define_kinematics()
         self.wheel_attachment.set_vel(self.frame, 0)
 
-    def define_loads(self):
-        """Define the loads acting upon the front frame."""
-        super().define_loads()
-
     @property
     @abstractmethod
     def wheel_axis(self) -> Vector:

--- a/src/brim/bicycle/grounds.py
+++ b/src/brim/bicycle/grounds.py
@@ -32,10 +32,6 @@ class GroundBase(ModelBase):
         super().define_kinematics()
         self.origin.set_vel(self.frame, 0)
 
-    def define_loads(self) -> None:
-        """Define the loads acting upon the ground."""
-        super().define_loads()
-
     @property
     def body(self) -> RigidBody:
         """The body representing the ground."""

--- a/src/brim/bicycle/wheels.py
+++ b/src/brim/bicycle/wheels.py
@@ -57,14 +57,6 @@ class KnifeEdgeWheel(WheelBase):
                                             *symbols(self._add_prefix("ixx iyy ixx")))
         self.symbols["r"] = Symbol(self._add_prefix("r"))
 
-    def define_kinematics(self) -> None:
-        """Define the kinematics of the wheel."""
-        super().define_kinematics()
-
-    def define_loads(self) -> None:
-        """Define the loads acting upon the wheel."""
-        super().define_loads()
-
     @property
     def center(self) -> Point:
         """Point representing the center of the wheel."""
@@ -105,14 +97,6 @@ class ToroidalWheel(WheelBase):
                                             *symbols(self._add_prefix("ixx iyy ixx")))
         self.symbols["r"] = Symbol(self._add_prefix("r"))
         self.symbols["tr"] = Symbol(self._add_prefix("tr"))
-
-    def define_kinematics(self) -> None:
-        """Define the kinematics of the wheel."""
-        super().define_kinematics()
-
-    def define_loads(self) -> None:
-        """Define the loads acting upon the wheel."""
-        super().define_loads()
 
     @property
     def center(self) -> Point:

--- a/src/brim/core/model_base.py
+++ b/src/brim/core/model_base.py
@@ -1,7 +1,7 @@
 """Module containing the base class for all models in BRiM."""
 from __future__ import annotations
 
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 from typing import TYPE_CHECKING, Any
 
 from sympy import symbols
@@ -210,15 +210,12 @@ class ConnectionBase(BrimBase, metaclass=ConnectionMeta):
         for req in self.required_models:
             setattr(self, f"_{req.attribute_name}", None)
 
-    @abstractmethod
     def define_objects(self) -> None:
         """Define the objects in the connection."""
 
-    @abstractmethod
     def define_kinematics(self) -> None:
         """Define the kinematics of the connection."""
 
-    @abstractmethod
     def define_loads(self) -> None:
         """Define the loads on the connection."""
 
@@ -264,19 +261,16 @@ class ModelBase(BrimBase, metaclass=ModelMeta):
         for submodel in self.submodels:
             submodel.define_connections()
 
-    @abstractmethod
     def define_objects(self) -> None:
         """Initialize the objects belonging to the model."""
         for submodel in self.submodels:
             submodel.define_objects()
 
-    @abstractmethod
     def define_kinematics(self) -> None:
         """Establish the kinematics of the objects belonging to the model."""
         for submodel in self.submodels:
             submodel.define_kinematics()
 
-    @abstractmethod
     def define_loads(self) -> None:
         """Define the loads that are part of the model."""
         for submodel in self.submodels:

--- a/src/brim/rider/connections.py
+++ b/src/brim/rider/connections.py
@@ -82,7 +82,3 @@ class RiderLeanConnection(ConnectionBase):
                      self.q[0], self.u[0], self.lean_point, self.rider.lean_point,
                      self.lean_axis, self.rider.lean_axis)
         )
-
-    def define_loads(self) -> None:
-        """Define the loads of the rider lean connection for the rear frame."""
-        super().define_loads()


### PR DESCRIPTION
Reason: it is not always necessary to implement them, so this way the use is not obligated to write that code.