### PR TITLE
Document public modules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,8 @@
-# Configuration file for the Sphinx documentation builder.
-#
-# For the full list of built-in configuration values, see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
+"""Configuration file for the Sphinx documentation builder.
+
+For the full list of built-in configuration values, see the documentation:
+https://www.sphinx-doc.org/en/master/usage/configuration.html
+"""
 import os
 import sys
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ target-version = "py38"
 line-length = 88
 select = ["A", "B", "C", "D", "E", "F", "I", "N", "Q", "W", "NPY", "RUF", "SIM", "TID",
           "T20", "UP"]
-ignore = ["A003", "D100", "D104", "D105", "D107", "D203", "D213"]
+ignore = ["A003", "D104", "D105", "D107", "D203", "D213"]
 show-source = true
 
 [tool.ruff.per-file-ignores]

--- a/src/brim/core/mixins.py
+++ b/src/brim/core/mixins.py
@@ -1,3 +1,4 @@
+"""Mixin classes providing common properties for models."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/brim/core/registry.py
+++ b/src/brim/core/registry.py
@@ -1,3 +1,4 @@
+"""Registry to keep track of all existing model and connection types in BRiM."""
 from __future__ import annotations
 
 from brim.core.singleton import Singleton

--- a/src/brim/core/singleton.py
+++ b/src/brim/core/singleton.py
@@ -1,3 +1,4 @@
+"""Singleton class."""
 from __future__ import annotations
 
 __all__ = ["SingletonMeta", "Singleton"]

--- a/src/brim/rider/connections.py
+++ b/src/brim/rider/connections.py
@@ -1,3 +1,4 @@
+"""Module containing the connections between the rider and the bicycle."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/brim/rider/rider_lean.py
+++ b/src/brim/rider/rider_lean.py
@@ -1,3 +1,4 @@
+"""Module containing rider lean models."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING


### PR DESCRIPTION
Noticed, that I've accidentally ignored the obligation to add a docstring to public modules, so hereby I've activated the check again. This is also useful, as it is used in the online documentation.