### PR TITLE
Several small fixes

### DIFF
--- a/src/brim/bicycle/rear_frames.py
+++ b/src/brim/bicycle/rear_frames.py
@@ -12,6 +12,7 @@ from brim.core import ModelBase, NewtonianBodyMixin, set_default_formulation
 try:  # pragma: no cover
     import numpy as np
     from bicycleparameters.io import remove_uncertainties
+    from bicycleparameters.main import calculate_benchmark_from_measured
     from bicycleparameters.rider import yeadon_vec_to_bicycle_vec
     from dtk.bicycle import benchmark_to_moore
 
@@ -170,7 +171,11 @@ class RigidRearFrameMoore(RigidRearFrame):
         """Get the parameter values of the rear frame."""
         params = super().get_param_values(bicycle_parameters)
         if "Benchmark" in bicycle_parameters.parameters:
-            bp = remove_uncertainties(bicycle_parameters.parameters["Benchmark"])
+            if bicycle_parameters.hasRider:
+                bp = remove_uncertainties(calculate_benchmark_from_measured(
+                    bicycle_parameters.parameters["Measured"])[0])
+            else:
+                bp = remove_uncertainties(bicycle_parameters.parameters["Benchmark"])
             mop = benchmark_to_moore(bp)
             params[self.body.mass] = mop["mc"]
             params.update(get_inertia_vals(

--- a/src/brim/core/model_base.py
+++ b/src/brim/core/model_base.py
@@ -65,7 +65,6 @@ def _create_connection_property(requirement: ConnectionRequirement) -> property:
                 f"of {requirement.type_name}, but {conn!r} is an instance of "
                 f"{type(conn)}.")
         setattr(self, f"_{requirement.attribute_name}", conn)
-        conn._parent = self
 
     getter.__annotations__ = {"return": requirement.type_hint}
     setter.__annotations__ = {"conn": requirement.type_hint, "return": None}
@@ -377,7 +376,6 @@ class ConnectionBase(BrimBase, metaclass=ConnectionMeta):
             Name of the connection.
         """
         super().__init__(name)
-        self._parent = None
         self._load_groups = []
         for req in self.required_models:
             setattr(self, f"_{req.attribute_name}", None)

--- a/src/brim/utilities/plotting.py
+++ b/src/brim/utilities/plotting.py
@@ -22,6 +22,7 @@ from brim.core import ConnectionBase, ModelBase, NewtonianBodyMixin
 from brim.rider.arms import PinElbowStickArmMixin
 from brim.rider.legs import TwoPinStickLegMixin
 from brim.rider.pelvis import PelvisBase
+from brim.rider.pelvis_to_torso import PelvisToTorsoBase
 from brim.rider.torso import TorsoBase
 
 if TYPE_CHECKING:
@@ -70,10 +71,10 @@ class Plotter(SymMePlotter):
         if (isinstance(model, WhippleBicycleMoore) and add_submodels
                 and model.pedals is not None):
             rf = model.rear_frame
-            ax_l = 0.1 * model.pedals.center_point.pos_from(
+            ax_l = 0.15 * model.pedals.center_point.pos_from(
                 rf.wheel_attachment).magnitude()
             saddle_low = rf.saddle.locatenew(
-                "P", 0.1 * model.pedals.center_point.pos_from(rf.saddle))
+                "P", 0.15 * model.pedals.center_point.pos_from(rf.saddle))
             self.add_line([
                 model.pedals.center_point,
                 saddle_low,
@@ -83,9 +84,12 @@ class Plotter(SymMePlotter):
                 saddle_low,
                 rf.saddle,
                 saddle_low,
-                rf.steer_attachment,
+                rf.steer_attachment.locatenew(  # not perfect but close enough
+                    "P", saddle_low.pos_from(rf.steer_attachment).dot(
+                        rf.steer_axis) / 2 * rf.steer_axis),
                 model.pedals.center_point,
             ], model.name)
+            self.add_body(rf.body)
             add_submodels = False
             for submodel in model.submodels:
                 if submodel is not rf:
@@ -151,6 +155,11 @@ class Plotter(SymMePlotter):
                 model.left_shoulder_point,
                 model.right_shoulder_point,
                 model.body.masscenter],
+                model.name)
+        elif isinstance(model, PelvisToTorsoBase):
+            self.add_line([
+                model.pelvis.body.masscenter,
+                model.torso.body.masscenter],
                 model.name)
         if add_submodels:
             for submodel in model.submodels:

--- a/tests/core/test_mixins.py
+++ b/tests/core/test_mixins.py
@@ -12,7 +12,7 @@ class MyModel(NewtonianBodyMixin, ModelBase):
 class TestNewtonianBodyMixin:
     def test_mixin(self) -> None:
         model = MyModel("name")
-        model.define_objects()
+        model.define_all()
         assert isinstance(model.body, RigidBody)
         assert model.system.bodies[0] is model.body
         assert model.frame is model.body.frame
@@ -20,3 +20,4 @@ class TestNewtonianBodyMixin:
         assert model.y is model.frame.y
         assert model.z is model.frame.z
         assert model.system.origin is model.body.masscenter
+        assert model.body.masscenter.vel(model.frame) == 0


### PR DESCRIPTION
This PR fixes several small problems:
- It checks whether the CoM velocity in the bodies created with the Newtonian body mixin are indeed zero. Thought this was already the case, and it indeed is. However the location that actually sets the velocity to zero in the body-fixed frame is not within the `RigidBody` class, but within the `System` class.
- It removes the redundant `_parent` attributes, which was left in on accident from a previous design (#50).
- It fixes the problem with bicycle parameters adjusting the rear frame CoM (#54).
- It improves the plotting a bit (#43).