### PR TITLE
Improve the name of the pelvis and torso models

### DIFF
--- a/src/brim/__init__.py
+++ b/src/brim/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
 
     "PlanarPelvis",
 
-    "SimpleRigidTorso",
+    "PlanarTorso",
 
     "PinElbowStickLeftArm", "PinElbowStickRightArm",
 
@@ -65,8 +65,8 @@ from brim.rider import (
     PinLeftHip,
     PinRightHip,
     PlanarPelvis,
+    PlanarTorso,
     Rider,
-    SimpleRigidTorso,
     SphericalLeftHip,
     SphericalLeftShoulder,
     SphericalRightHip,

--- a/src/brim/__init__.py
+++ b/src/brim/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
 
     "Rider",
 
-    "SimpleRigidPelvis",
+    "PlanarPelvis",
 
     "SimpleRigidTorso",
 
@@ -64,8 +64,8 @@ from brim.rider import (
     PinElbowStickRightArm,
     PinLeftHip,
     PinRightHip,
+    PlanarPelvis,
     Rider,
-    SimpleRigidPelvis,
     SimpleRigidTorso,
     SphericalLeftHip,
     SphericalLeftShoulder,

--- a/src/brim/rider/__init__.py
+++ b/src/brim/rider/__init__.py
@@ -10,7 +10,7 @@ __all__ = [
 
     "PelvisBase", "PlanarPelvis",
 
-    "TorsoBase", "SimpleRigidTorso",
+    "TorsoBase", "PlanarTorso",
 
     "ArmBase", "LeftArmBase", "RightArmBase", "PinElbowStickLeftArm",
     "PinElbowStickRightArm",
@@ -64,4 +64,4 @@ from brim.rider.pelvis_to_torso import FixedPelvisToTorso
 from brim.rider.rider import Rider
 from brim.rider.rider_lean import RiderLean
 from brim.rider.shoulder_joints import SphericalLeftShoulder, SphericalRightShoulder
-from brim.rider.torso import SimpleRigidTorso, TorsoBase
+from brim.rider.torso import PlanarTorso, TorsoBase

--- a/src/brim/rider/__init__.py
+++ b/src/brim/rider/__init__.py
@@ -8,7 +8,7 @@ __all__ = [
     "HipBase", "LeftHipBase", "RightHipBase", "PelvisToTorsoBase",
     "LeftShoulderBase", "RightShoulderBase", "ShoulderBase",
 
-    "PelvisBase", "SimpleRigidPelvis",
+    "PelvisBase", "PlanarPelvis",
 
     "TorsoBase", "SimpleRigidTorso",
 
@@ -59,7 +59,7 @@ from brim.rider.legs import (
     TwoPinStickLeftLeg,
     TwoPinStickRightLeg,
 )
-from brim.rider.pelvis import PelvisBase, SimpleRigidPelvis
+from brim.rider.pelvis import PelvisBase, PlanarPelvis
 from brim.rider.pelvis_to_torso import FixedPelvisToTorso
 from brim.rider.rider import Rider
 from brim.rider.rider_lean import RiderLean

--- a/src/brim/rider/pelvis.py
+++ b/src/brim/rider/pelvis.py
@@ -18,7 +18,7 @@ try:  # pragma: no cover
 except ImportError:  # pragma: no cover
     pass
 
-__all__ = ["PelvisBase", "SimpleRigidPelvis"]
+__all__ = ["PelvisBase", "PlanarPelvis"]
 
 
 class PelvisBase(NewtonianBodyMixin, ModelBase):
@@ -63,12 +63,12 @@ class PelvisBase(NewtonianBodyMixin, ModelBase):
         return params
 
 
-class SimpleRigidPelvis(PelvisBase):
-    """A simple rigid pelvis.
+class PlanarPelvis(PelvisBase):
+    """A planar rigid pelvis.
 
     Explanation
     -----------
-    The simple rigid pelvis models the pelvis as being a rigid body. The hip joints are
+    The planar rigid pelvis models the pelvis as being a rigid body. The hip joints are
     located a hip width apart from each other with the center of mass at the center.
     """
 

--- a/src/brim/rider/torso.py
+++ b/src/brim/rider/torso.py
@@ -23,7 +23,7 @@ except ImportError:  # pragma: no cover
 if TYPE_CHECKING:
     from sympy.physics.mechanics import ReferenceFrame
 
-__all__ = ["TorsoBase", "SimpleRigidTorso"]
+__all__ = ["TorsoBase", "PlanarTorso"]
 
 
 class TorsoBase(NewtonianBodyMixin, ModelBase):
@@ -93,12 +93,12 @@ class TorsoBase(NewtonianBodyMixin, ModelBase):
         return params
 
 
-class SimpleRigidTorso(TorsoBase):
-    """A simple rigid torso.
+class PlanarTorso(TorsoBase):
+    """A planar rigid torso.
 
     Explanation
     -----------
-    The simple rigid torso models the torso as being rigid. The shoulder joints are
+    The planar rigid torso models the torso as being rigid. The shoulder joints are
     located a shoulder width apart at a height of the shoulder height above the center
     of mass of the torso.
     """

--- a/tests/brim/test_bicycle_rider.py
+++ b/tests/brim/test_bicycle_rider.py
@@ -22,8 +22,8 @@ from brim.rider import (
     PinElbowStickLeftArm,
     PinElbowStickRightArm,
     PlanarPelvis,
+    PlanarTorso,
     Rider,
-    SimpleRigidTorso,
     SphericalLeftHip,
     SphericalLeftShoulder,
     SphericalRightHip,
@@ -59,7 +59,7 @@ class TestCompleteBicycleRider:
     def _rider_setup(self) -> None:
         self.rider = Rider("rider")
         self.rider.pelvis = PlanarPelvis("pelvis")
-        self.rider.torso = SimpleRigidTorso("torso")
+        self.rider.torso = PlanarTorso("torso")
         self.rider.left_arm = PinElbowStickLeftArm("left_arm")
         self.rider.right_arm = PinElbowStickRightArm("right_arm")
         self.rider.left_leg = TwoPinStickLeftLeg("left_leg")

--- a/tests/brim/test_bicycle_rider.py
+++ b/tests/brim/test_bicycle_rider.py
@@ -21,8 +21,8 @@ from brim.rider import (
     FixedPelvisToTorso,
     PinElbowStickLeftArm,
     PinElbowStickRightArm,
+    PlanarPelvis,
     Rider,
-    SimpleRigidPelvis,
     SimpleRigidTorso,
     SphericalLeftHip,
     SphericalLeftShoulder,
@@ -58,7 +58,7 @@ class TestCompleteBicycleRider:
     @pytest.fixture()
     def _rider_setup(self) -> None:
         self.rider = Rider("rider")
-        self.rider.pelvis = SimpleRigidPelvis("pelvis")
+        self.rider.pelvis = PlanarPelvis("pelvis")
         self.rider.torso = SimpleRigidTorso("torso")
         self.rider.left_arm = PinElbowStickLeftArm("left_arm")
         self.rider.right_arm = PinElbowStickRightArm("right_arm")

--- a/tests/brim/test_seat_connections.py
+++ b/tests/brim/test_seat_connections.py
@@ -4,7 +4,7 @@ import pytest
 from brim.bicycle.rear_frames import RigidRearFrameMoore
 from brim.brim.base_connections import SeatConnectionBase
 from brim.brim.seat_connections import SideLeanConnection
-from brim.rider.pelvis import SimpleRigidPelvis
+from brim.rider.pelvis import PlanarPelvis
 from brim.utilities.testing import _test_descriptions, create_model_of_connection
 from sympy import simplify, zeros
 from sympy.physics.mechanics import ReferenceFrame
@@ -15,7 +15,7 @@ class TestSeatConnectionBase:
     @pytest.fixture(autouse=True)
     def _setup(self, seat_cls) -> None:
         self.model = create_model_of_connection(seat_cls)("model")
-        self.model.pelvis = SimpleRigidPelvis("pelvis")
+        self.model.pelvis = PlanarPelvis("pelvis")
         self.model.rear_frame = RigidRearFrameMoore("rear_frame")
         self.model.conn = seat_cls("seat_connection")
         self.model.define_connections()
@@ -35,7 +35,7 @@ class TestSideLeanConnection:
     @pytest.fixture(autouse=True)
     def _setup(self) -> None:
         self.model = create_model_of_connection(SideLeanConnection)("model")
-        self.model.pelvis = SimpleRigidPelvis("pelvis")
+        self.model.pelvis = PlanarPelvis("pelvis")
         self.model.rear_frame = RigidRearFrameMoore("rear_frame")
         self.model.conn = SideLeanConnection("seat_connection")
         self.pelvis, self.rear_frame, self.conn = (

--- a/tests/rider/test_hip_joints.py
+++ b/tests/rider/test_hip_joints.py
@@ -10,7 +10,7 @@ from brim.rider.hip_joints import (
     SphericalRightHip,
 )
 from brim.rider.legs import LegBase, TwoPinStickLeftLeg, TwoPinStickRightLeg
-from brim.rider.pelvis import PelvisBase, SimpleRigidPelvis
+from brim.rider.pelvis import PelvisBase, PlanarPelvis
 from brim.utilities.testing import _test_descriptions
 
 
@@ -52,13 +52,13 @@ class HipModel(ModelBase):
 class TestHipJointBase:
     def test_types(self, hip_cls, leg_cls, base_cls) -> None:
         hip = hip_cls("hip")
-        hip.pelvis = SimpleRigidPelvis("pelvis")
+        hip.pelvis = PlanarPelvis("pelvis")
         hip.leg = leg_cls("leg")
         assert isinstance(hip, base_cls)
 
     def test_descriptions(self, hip_cls, leg_cls, base_cls) -> None:
         hip = hip_cls("hip")
-        hip.pelvis = SimpleRigidPelvis("pelvis")
+        hip.pelvis = PlanarPelvis("pelvis")
         hip.leg = leg_cls("leg")
         _test_descriptions(hip)
 
@@ -68,7 +68,7 @@ class TestSphericalLeftHipJoint:
     def _setup(self) -> None:
         self.model = HipModel("model")
         self.model.hip = SphericalLeftHip("hip")
-        self.model.pelvis = SimpleRigidPelvis("pelvis")
+        self.model.pelvis = PlanarPelvis("pelvis")
         self.model.leg = TwoPinStickLeftLeg("leg")
         self.model.define_all()
         self.hip, self.pelvis, self.leg = (
@@ -89,7 +89,7 @@ class TestSphericalRightHipJoint:
     def _setup(self) -> None:
         self.model = HipModel("model")
         self.model.hip = SphericalRightHip("hip")
-        self.model.pelvis = SimpleRigidPelvis("pelvis")
+        self.model.pelvis = PlanarPelvis("pelvis")
         self.model.leg = TwoPinStickRightLeg("leg")
         self.model.define_all()
         self.hip, self.pelvis, self.leg = (
@@ -112,7 +112,7 @@ class TestPinLeftHipJoint:
     def _setup(self, hip_cls, leg_cls) -> None:
         self.model = HipModel("model")
         self.model.hip = hip_cls("hip")
-        self.model.pelvis = SimpleRigidPelvis("pelvis")
+        self.model.pelvis = PlanarPelvis("pelvis")
         self.model.leg = leg_cls("leg")
         self.model.define_all()
         self.hip, self.pelvis, self.leg = (

--- a/tests/rider/test_pelvis.py
+++ b/tests/rider/test_pelvis.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import pytest
-from brim.rider.pelvis import PelvisBase, SimpleRigidPelvis
+from brim.rider.pelvis import PelvisBase, PlanarPelvis
 from brim.utilities.testing import _test_descriptions
 from sympy.physics.mechanics import Point, RigidBody
 
 
-@pytest.mark.parametrize("pelvis_cls", [SimpleRigidPelvis])
+@pytest.mark.parametrize("pelvis_cls", [PlanarPelvis])
 class TestPelvisBase:
     def test_types(self, pelvis_cls) -> None:
         pelvis = pelvis_cls("pelvis")
@@ -23,7 +23,7 @@ class TestPelvisBase:
 class TestSimpleRigidPelvis:
     @pytest.fixture(autouse=True)
     def _setup(self) -> None:
-        self.pelvis = SimpleRigidPelvis("pelvis")
+        self.pelvis = PlanarPelvis("pelvis")
         self.pelvis.define_objects()
         self.pelvis.define_kinematics()
         self.pelvis.define_loads()

--- a/tests/rider/test_pelvis_to_torso.py
+++ b/tests/rider/test_pelvis_to_torso.py
@@ -4,13 +4,13 @@ import pytest
 from brim.rider.base_connections import PelvisToTorsoBase
 from brim.rider.pelvis import PlanarPelvis
 from brim.rider.pelvis_to_torso import FixedPelvisToTorso
-from brim.rider.torso import SimpleRigidTorso
+from brim.rider.torso import PlanarTorso
 from brim.utilities.testing import _test_descriptions, create_model_of_connection
 from sympy import eye
 
 
 @pytest.mark.parametrize("pelvis_cls, torso_cls, pelvis_to_torso_cls", [
-    (PlanarPelvis, SimpleRigidTorso, FixedPelvisToTorso),
+    (PlanarPelvis, PlanarTorso, FixedPelvisToTorso),
 ])
 class TestPelvisToTorsoBase:
     @pytest.fixture(autouse=True)
@@ -35,7 +35,7 @@ class TestFixedPelvisToTorso:
     def _setup(self) -> None:
         self.model = create_model_of_connection(FixedPelvisToTorso)("model")
         self.model.pelvis = PlanarPelvis("pelvis")
-        self.model.torso = SimpleRigidTorso("torso")
+        self.model.torso = PlanarTorso("torso")
         self.model.conn = FixedPelvisToTorso("pelvis_to_torso")
         self.pelvis, self.torso, self.conn = (
             self.model.pelvis, self.model.torso, self.model.conn)

--- a/tests/rider/test_pelvis_to_torso.py
+++ b/tests/rider/test_pelvis_to_torso.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 from brim.rider.base_connections import PelvisToTorsoBase
-from brim.rider.pelvis import SimpleRigidPelvis
+from brim.rider.pelvis import PlanarPelvis
 from brim.rider.pelvis_to_torso import FixedPelvisToTorso
 from brim.rider.torso import SimpleRigidTorso
 from brim.utilities.testing import _test_descriptions, create_model_of_connection
@@ -10,7 +10,7 @@ from sympy import eye
 
 
 @pytest.mark.parametrize("pelvis_cls, torso_cls, pelvis_to_torso_cls", [
-    (SimpleRigidPelvis, SimpleRigidTorso, FixedPelvisToTorso),
+    (PlanarPelvis, SimpleRigidTorso, FixedPelvisToTorso),
 ])
 class TestPelvisToTorsoBase:
     @pytest.fixture(autouse=True)
@@ -34,7 +34,7 @@ class TestFixedPelvisToTorso:
     @pytest.fixture(autouse=True)
     def _setup(self) -> None:
         self.model = create_model_of_connection(FixedPelvisToTorso)("model")
-        self.model.pelvis = SimpleRigidPelvis("pelvis")
+        self.model.pelvis = PlanarPelvis("pelvis")
         self.model.torso = SimpleRigidTorso("torso")
         self.model.conn = FixedPelvisToTorso("pelvis_to_torso")
         self.pelvis, self.torso, self.conn = (

--- a/tests/rider/test_rider.py
+++ b/tests/rider/test_rider.py
@@ -6,8 +6,8 @@ from brim.rider import (
     PinElbowStickLeftArm,
     PinElbowStickRightArm,
     PlanarPelvis,
+    PlanarTorso,
     Rider,
-    SimpleRigidTorso,
     SphericalLeftHip,
     SphericalLeftShoulder,
     SphericalRightHip,
@@ -22,7 +22,7 @@ class TestCompleteRider:
     def _setup(self) -> None:
         self.rider = Rider("rider")
         self.rider.pelvis = PlanarPelvis("pelvis")
-        self.rider.torso = SimpleRigidTorso("torso")
+        self.rider.torso = PlanarTorso("torso")
         self.rider.left_arm = PinElbowStickLeftArm("left_arm")
         self.rider.right_arm = PinElbowStickRightArm("right_arm")
         self.rider.left_leg = TwoPinStickLeftLeg("left_leg")

--- a/tests/rider/test_rider.py
+++ b/tests/rider/test_rider.py
@@ -5,8 +5,8 @@ from brim.rider import (
     FixedPelvisToTorso,
     PinElbowStickLeftArm,
     PinElbowStickRightArm,
+    PlanarPelvis,
     Rider,
-    SimpleRigidPelvis,
     SimpleRigidTorso,
     SphericalLeftHip,
     SphericalLeftShoulder,
@@ -21,7 +21,7 @@ class TestCompleteRider:
     @pytest.fixture()
     def _setup(self) -> None:
         self.rider = Rider("rider")
-        self.rider.pelvis = SimpleRigidPelvis("pelvis")
+        self.rider.pelvis = PlanarPelvis("pelvis")
         self.rider.torso = SimpleRigidTorso("torso")
         self.rider.left_arm = PinElbowStickLeftArm("left_arm")
         self.rider.right_arm = PinElbowStickRightArm("right_arm")
@@ -51,7 +51,7 @@ class TestCompleteRider:
         rider = Rider("rider")
         with pytest.raises(Exception):
             rider.define_all()
-        rider.pelvis = SimpleRigidPelvis("pelvis")
+        rider.pelvis = PlanarPelvis("pelvis")
         rider.define_all()
 
     def test_form_eoms(self, _setup) -> None:

--- a/tests/rider/test_schoulder_joints.py
+++ b/tests/rider/test_schoulder_joints.py
@@ -9,7 +9,7 @@ from brim.rider.base_connections import (
     ShoulderBase,
 )
 from brim.rider.shoulder_joints import SphericalLeftShoulder, SphericalRightShoulder
-from brim.rider.torso import SimpleRigidTorso, TorsoBase
+from brim.rider.torso import PlanarTorso, TorsoBase
 from brim.utilities.testing import _test_descriptions
 
 
@@ -50,13 +50,13 @@ class ShoulderModel(ModelBase):
 class TestShoulderJointBase:
     def test_types(self, shoulder_cls, arm_cls, base_cls) -> None:
         shoulder = shoulder_cls("shoulder")
-        shoulder.torso = SimpleRigidTorso("torso")
+        shoulder.torso = PlanarTorso("torso")
         shoulder.arm = arm_cls("arm")
         assert isinstance(shoulder, base_cls)
 
     def test_descriptions(self, shoulder_cls, arm_cls, base_cls) -> None:
         shoulder = shoulder_cls("shoulder")
-        shoulder.torso = SimpleRigidTorso("torso")
+        shoulder.torso = PlanarTorso("torso")
         shoulder.arm = arm_cls("arm")
         _test_descriptions(shoulder)
 
@@ -66,7 +66,7 @@ class TestSphericalLeftShoulderJoint:
     def _setup(self) -> None:
         self.model = ShoulderModel("model")
         self.model.shoulder = SphericalLeftShoulder("shoulder")
-        self.model.torso = SimpleRigidTorso("torso")
+        self.model.torso = PlanarTorso("torso")
         self.model.arm = PinElbowStickLeftArm("arm")
         self.model.define_all()
         self.shoulder, self.torso, self.arm = (
@@ -87,7 +87,7 @@ class TestSphericalRightShoulderJoint:
     def _setup(self) -> None:
         self.model = ShoulderModel("model")
         self.model.shoulder = SphericalRightShoulder("shoulder")
-        self.model.torso = SimpleRigidTorso("torso")
+        self.model.torso = PlanarTorso("torso")
         self.model.arm = PinElbowStickRightArm("arm")
         self.model.define_all()
         self.shoulder, self.torso, self.arm = (

--- a/tests/rider/test_torso.py
+++ b/tests/rider/test_torso.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import pytest
-from brim.rider.torso import SimpleRigidTorso, TorsoBase
+from brim.rider.torso import PlanarTorso, TorsoBase
 from brim.utilities.testing import _test_descriptions
 from sympy.physics.mechanics import Point, RigidBody
 
 
-@pytest.mark.parametrize("torso_cls", [SimpleRigidTorso])
+@pytest.mark.parametrize("torso_cls", [PlanarTorso])
 class TestTorsoBase:
     def test_types(self, torso_cls) -> None:
         torso = torso_cls("torso")
@@ -23,7 +23,7 @@ class TestTorsoBase:
 class TestSimpleRigidTorso:
     @pytest.fixture(autouse=True)
     def _setup(self) -> None:
-        self.torso = SimpleRigidTorso("torso")
+        self.torso = PlanarTorso("torso")
         self.torso.define_objects()
         self.torso.define_kinematics()
         self.torso.define_loads()

--- a/tests/utilities/test_parametrize.py
+++ b/tests/utilities/test_parametrize.py
@@ -16,7 +16,7 @@ from brim.brim.steer_connections import HolonomicSteerConnection
 from brim.rider.arms import PinElbowStickLeftArm, PinElbowStickRightArm
 from brim.rider.hip_joints import SphericalLeftHip, SphericalRightHip
 from brim.rider.legs import TwoPinStickLeftLeg, TwoPinStickRightLeg
-from brim.rider.pelvis import SimpleRigidPelvis
+from brim.rider.pelvis import PlanarPelvis
 from brim.rider.pelvis_to_torso import FixedPelvisToTorso
 from brim.rider.rider import Rider
 from brim.rider.shoulder_joints import SphericalLeftShoulder, SphericalRightShoulder
@@ -87,7 +87,7 @@ class TestParametrize:
         self.bike.ground = FlatGround("ground")
 
         self.rider = Rider("rider")
-        self.rider.pelvis = SimpleRigidPelvis("pelvis")
+        self.rider.pelvis = PlanarPelvis("pelvis")
         self.rider.torso = SimpleRigidTorso("torso")
         self.rider.left_arm = PinElbowStickLeftArm("left_arm")
         self.rider.right_arm = PinElbowStickRightArm("right_arm")

--- a/tests/utilities/test_parametrize.py
+++ b/tests/utilities/test_parametrize.py
@@ -20,7 +20,7 @@ from brim.rider.pelvis import PlanarPelvis
 from brim.rider.pelvis_to_torso import FixedPelvisToTorso
 from brim.rider.rider import Rider
 from brim.rider.shoulder_joints import SphericalLeftShoulder, SphericalRightShoulder
-from brim.rider.torso import SimpleRigidTorso
+from brim.rider.torso import PlanarTorso
 from sympy import diag
 from sympy.physics.mechanics import RigidBody, msubs
 
@@ -88,7 +88,7 @@ class TestParametrize:
 
         self.rider = Rider("rider")
         self.rider.pelvis = PlanarPelvis("pelvis")
-        self.rider.torso = SimpleRigidTorso("torso")
+        self.rider.torso = PlanarTorso("torso")
         self.rider.left_arm = PinElbowStickLeftArm("left_arm")
         self.rider.right_arm = PinElbowStickRightArm("right_arm")
         self.rider.left_leg = TwoPinStickLeftLeg("left_leg")


### PR DESCRIPTION
Part of #41 
In general one should never name a model `Simple...`. This is more accurate.